### PR TITLE
J2534: use XML file for library info (Linux), refactoring, helper functions

### DIFF
--- a/FreeSSM.pro
+++ b/FreeSSM.pro
@@ -25,6 +25,7 @@ HEADERS += src/FreeSSM.h \
            src/SerialPassThroughDiagInterface.h \
            src/J2534DiagInterface.h \
            src/J2534.h \
+           src/J2534misc.h \
            src/SSMP1communication.h \
            src/SSMP1communication_procedures.h \
            src/SSMP1base.h \
@@ -72,6 +73,7 @@ SOURCES += src/main.cpp \
            src/ATcommandControlledDiagInterface.cpp \
            src/SerialPassThroughDiagInterface.cpp \
            src/J2534DiagInterface.cpp \
+           src/J2534misc.cpp \
            src/SSMP1communication.cpp \
            src/SSMP1communication_procedures.cpp \
            src/SSMP1base.cpp \
@@ -214,3 +216,10 @@ win32 {
                   src/windows/J2534_API.cpp
        RC_FILE = resources/FreeSSM_WinAppIcon.rc
 }
+
+DISTFILES += \
+    definitions/J2534Libs.xml \
+    definitions/SSM1defs_ABS.xml \
+    definitions/SSM1defs_AirConditioning.xml \
+    definitions/SSM1defs_CruiseControl.xml \
+    definitions/SSM1defs_Engine.xml

--- a/definitions/J2534Libs.xml
+++ b/definitions/J2534Libs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+	J2534Libs.xml - Define J2534-libraries for Linux
+
+	(c) 2016 MartinX
+
+-->
+<J2534LIBS>
+<!--
+	<J2534LIB name="libj2534.so" api="02.02" path="./libj2534_v0202.so" >
+		<PROTOCOLS>
+			<PROTOCOL>ISO9141</PROTOCOL>
+		</PROTOCOLS>
+	</J2534LIB>
+-->
+	<J2534LIB name="libj2534.so" api="04.04" path="./libj2534.so" >
+		<PROTOCOLS>
+			<PROTOCOL>ISO15765</PROTOCOL>
+			<PROTOCOL>ISO14230</PROTOCOL>
+			<PROTOCOL>ISO9141</PROTOCOL>
+		</PROTOCOLS>
+	</J2534LIB>
+</J2534LIBS>

--- a/src/AddMBsSWsDlg.cpp
+++ b/src/AddMBsSWsDlg.cpp
@@ -33,6 +33,9 @@ AddMBsSWsDlg::AddMBsSWsDlg(QWidget *parent, std::vector<mb_dt> supportedMBs, std
 	_unselectedMBsSWs_metaList.clear();
 	// Setup GUI:
 	setupUi(this);
+	// enable maximize and minimize buttons
+	//   GNOME 3 at least: this also enables fast window management e.g. "View split on left" (Super-Left), "... right" (Super-Right)
+	setWindowFlags( Qt::Window );
 	setupUiFonts();
 	// SAVE AND OUTPUT AVAILABLE (UNSELECTED) MBs:
 	tmpMBSWmd.blockType = 0;

--- a/src/ControlUnitDialog.cpp
+++ b/src/ControlUnitDialog.cpp
@@ -30,6 +30,9 @@ ControlUnitDialog::ControlUnitDialog(QString title, AbstractDiagInterface *diagI
 	_contentWidget = NULL;
 	// Setup GUI:
 	setupUi(this);
+	// enable maximize and minimize buttons
+	//   GNOME 3 at least: this also enables fast window management e.g. "View split on left" (Super-Left), "... right" (Super-Right)
+	setWindowFlags( Qt::Window );
 	setupUiFonts();
 	// Move window to desired coordinates:
 	move( 30, 30 );

--- a/src/J2534misc.cpp
+++ b/src/J2534misc.cpp
@@ -1,0 +1,109 @@
+/*
+ * J2534misc.cpp -  J2534-related miscellaneous functionality
+ *
+ * Copyright (C) 2009-2016 Comer352l, 2016 MartinX
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "J2534misc.h"
+
+
+static std::string toupper(const std::string& s)
+{
+	std::string result(s.length(), '\0');
+	for (size_t i = 0; i < result.length(); ++i)
+		result[i] = toupper(s[i]);
+	return result;
+}
+
+const std::map<std::string, J2534_protocol_flags> J2534misc::protocolsMap = initProtocolsMap();
+
+const std::map<std::string, J2534_protocol_flags> J2534misc::initProtocolsMap()
+{
+	std::map<std::string, J2534_protocol_flags> m;
+	m["J1850VPW"] = PROTOCOL_FLAG_J1850VPW;
+	m["J1850PWM"] = PROTOCOL_FLAG_J1850PWM;
+	m["ISO9141"] = PROTOCOL_FLAG_ISO9141;
+	m["ISO14230"] = PROTOCOL_FLAG_ISO14230;
+	m["CAN"] = PROTOCOL_FLAG_CAN;
+	m["ISO15765"] = PROTOCOL_FLAG_ISO15765;
+	m["SCI_A_ENGINE"] = PROTOCOL_FLAG_SCI_A_ENGINE;
+	m["SCI_A_TRANS"] = PROTOCOL_FLAG_SCI_A_TRANS;
+	m["SCI_B_ENGINE"] = PROTOCOL_FLAG_SCI_B_ENGINE;
+	m["SCI_B_TRANS"] = PROTOCOL_FLAG_SCI_B_TRANS;
+	return m;
+}
+
+std::vector<std::string> J2534misc::protocolsToStr(const J2534_protocol_flags pflags)
+{
+	std::vector<std::string> vs;
+	for(std::map<std::string, J2534_protocol_flags>::const_iterator it = protocolsMap.begin(); it != protocolsMap.end(); ++it) {
+		if (pflags & (*it).second)
+			vs.push_back((*it).first);
+	}
+	return vs;
+}
+
+J2534_protocol_flags J2534misc::parseProtocol(const std::string& s)
+{
+	std::string key = toupper(s);
+	std::map<std::string, J2534_protocol_flags>::const_iterator it = protocolsMap.find(key);
+	return (it != protocolsMap.end()) ? (*it).second : J2534_protocol_flags(0);
+}
+
+J2534_API_version J2534misc::parseApiVersion(const std::string& s)
+{
+	if (s == "02.02") return J2534_API_v0202;
+	if (s == "04.04") return J2534_API_v0404;
+	return J2534_API_UNDEFINED;
+}
+
+std::string J2534misc::apiVersionToStr(const J2534_API_version api)
+{
+	switch(api) {
+	case J2534_API_v0202 : return "02.02";
+	case J2534_API_v0404 : return "04.04";
+	default: return "UNDEFINED";
+	}
+}
+
+#ifdef __J2534_API_DEBUG__
+void J2534misc::printLibraryInfo(const std::vector<J2534Library>& PTlibraries)
+{
+	const size_t libcount = PTlibraries.size();
+	if (libcount)
+		std::cout << "Found " << libcount << " registered J2534-libraries:\n";
+	else
+		std::cout << "No J2534-libraries found.\n";
+
+	for (size_t k = 0; k < libcount; ++k)
+	{
+		const J2534Library& lib = PTlibraries.at(k);
+		std::cout << "\n  Name:        " << lib.name;
+		std::cout << "\n  Path:        " << lib.path;
+		std::cout << "\n  API-version: " << apiVersionToStr(lib.api);
+		std::cout << "\n  Protocols:   ";
+
+		std::vector<std::string> protocolStrings = protocolsToStr(lib.protocols);
+		for(size_t i = 0; i < protocolStrings.size(); ++i) {
+			if (i)
+				std::cout << " ";
+			std::cout << protocolStrings.at(i);
+		}
+		std::cout << "\n\n";
+	}
+}
+#endif

--- a/src/J2534misc.h
+++ b/src/J2534misc.h
@@ -1,0 +1,80 @@
+/*
+ * J2534misc.h - J2534-related miscellaneous functionality
+ *
+ * Copyright (C) 2009-2016 Comer352l, 2016 MartinX
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef J2534MISC_H
+#define J2534MISC_H
+
+
+#include <string>
+#include <map>
+#include <vector>
+
+#ifdef __J2534_API_DEBUG__
+#include <iostream>
+#endif
+
+#define		J2534API_ERROR_FCN_NOT_SUPPORTED	-1
+#define		J2534API_ERROR_INVALID_LIBRARY		-2
+
+
+enum J2534_API_version {J2534_API_UNDEFINED, J2534_API_v0202, J2534_API_v0404};
+
+enum J2534_protocol_flags
+{
+	PROTOCOL_FLAG_J1850VPW     = 0x01,
+	PROTOCOL_FLAG_J1850PWM     = 0x02,
+	PROTOCOL_FLAG_ISO9141      = 0x04,
+	PROTOCOL_FLAG_ISO14230     = 0x08,
+	PROTOCOL_FLAG_CAN          = 0x10,
+	PROTOCOL_FLAG_ISO15765     = 0x20,
+	PROTOCOL_FLAG_SCI_A_ENGINE = 0x40,
+	PROTOCOL_FLAG_SCI_A_TRANS  = 0x80,
+	PROTOCOL_FLAG_SCI_B_ENGINE = 0x100,
+	PROTOCOL_FLAG_SCI_B_TRANS  = 0x200,
+};
+
+class J2534Library
+{
+public:
+	std::string path;
+	std::string name;
+	J2534_protocol_flags protocols;
+	J2534_API_version api;
+
+	J2534Library() { protocols = J2534_protocol_flags(0); api = J2534_API_v0404; }
+};
+
+class J2534misc {
+public:
+	static J2534_protocol_flags parseProtocol(const std::string& s);
+	static std::vector<std::string> protocolsToStr(const J2534_protocol_flags pflags);
+	static J2534_API_version parseApiVersion(const std::string& s);
+	static std::string apiVersionToStr(const J2534_API_version api);
+
+#ifdef __J2534_API_DEBUG__
+	static void printLibraryInfo(const std::vector<J2534Library>& PTlibraries);
+#endif
+
+private:
+	const static std::map<std::string, J2534_protocol_flags> protocolsMap;
+
+	static const std::map<std::string, J2534_protocol_flags> initProtocolsMap();
+};
+
+#endif

--- a/src/libFSSM.cpp
+++ b/src/libFSSM.cpp
@@ -312,7 +312,7 @@ static char nibble_hexdigit(unsigned char value)
 std::string libFSSM::StrToHexstr(const char* inputstr, size_t nrbytes)
 {
 	if (inputstr == NULL)
-		return std::string{};
+		return std::string();
 	const char delimiter = ' ';
 	const size_t strlength = 3 * nrbytes - 1;
 	std::string s(strlength, delimiter);

--- a/src/linux/J2534_API.cpp
+++ b/src/linux/J2534_API.cpp
@@ -162,6 +162,14 @@ std::vector<J2534Library> J2534_API::getAvailableJ2534Libs()
 
 	// TODO
 
+	J2534Library lib1;
+	lib1.name = "libj2534client.so";
+	lib1.path = "/home/martin/cpp/J2534Client/libj2534client.so";
+	lib1.api = J2534_API_v0404;
+	lib1.protocols = PROTOCOL_FLAG_ISO15765 | PROTOCOL_FLAG_ISO14230 | PROTOCOL_FLAG_ISO9141;
+
+	PTlibraries.push_back(lib1);
+
 
 #ifdef __J2534_API_DEBUG__
 	printLibraryInfo(PTlibraries);

--- a/src/linux/J2534_API.h
+++ b/src/linux/J2534_API.h
@@ -23,10 +23,6 @@
 
 //#define __J2534_API_DEBUG__
 
-
-#ifdef __J2534_API_DEBUG__
-    #include <iostream>
-#endif
 #include <string>
 #include <vector>
 #include "../J2534.h"
@@ -36,40 +32,8 @@ extern "C"
     #include <errno.h>
     #include <dlfcn.h>
 }
-
-
-#define     J2534API_ERROR_FCN_NOT_SUPPORTED     -1
-#define     J2534API_ERROR_INVALID_LIBRARY       -2
-
-
-enum J2534_API_version {J2534_API_v0202, J2534_API_v0404};
-
-
-enum J2534_protocol_flags
-{
-	PROTOCOL_FLAG_J1850VPW     = 0x01,
-	PROTOCOL_FLAG_J1850PWM     = 0x02,
-	PROTOCOL_FLAG_ISO9141      = 0x04,
-	PROTOCOL_FLAG_ISO14230     = 0x08,
-	PROTOCOL_FLAG_CAN          = 0x10,
-	PROTOCOL_FLAG_ISO15765     = 0x20,
-	PROTOCOL_FLAG_SCI_A_ENGINE = 0x40,
-	PROTOCOL_FLAG_SCI_A_TRANS  = 0x80,
-	PROTOCOL_FLAG_SCI_B_ENGINE = 0x100,
-	PROTOCOL_FLAG_SCI_B_TRANS  = 0x200,
-};
-
-
-class J2534Library
-{
-public:
-	std::string path;
-	std::string name;
-	unsigned long protocols;
-	J2534_API_version api;
-
-	J2534Library() { protocols = 0; api = J2534_API_v0404; };
-};
+#include "J2534misc.h"
+#include "tinyxml/tinyxml.h"
 
 
 class J2534_API
@@ -125,12 +89,9 @@ private:
 	J2534_PassThruSetProgrammingVoltage_0404 _PassThruSetProgrammingVoltage_0404;
 
 	void assignJ2534fcns();
-#ifdef __J2534_API_DEBUG__
-	static void printLibraryInfo(std::vector<J2534Library> PTlibraries);
-#endif
+	static std::vector<J2534Library> parseJ2534LibsXml(const std::string& libsDefXmlFile);
 
 };
 
 
 #endif
-

--- a/src/windows/J2534_API.h
+++ b/src/windows/J2534_API.h
@@ -24,9 +24,6 @@
 //#define __J2534_API_DEBUG__
 
 
-#ifdef __J2534_API_DEBUG__
-    #include <iostream>
-#endif
 #include <string>
 #include <vector>
 #include "..\J2534.h"
@@ -35,40 +32,7 @@ extern "C"
 {
     #include "windows.h"
 }
-
-
-#define		J2534API_ERROR_FCN_NOT_SUPPORTED	-1
-#define		J2534API_ERROR_INVALID_LIBRARY		-2
-
-
-enum J2534_API_version {J2534_API_v0202, J2534_API_v0404};
-
-
-enum J2534_protocol_flags
-{
-	PROTOCOL_FLAG_J1850VPW     = 0x01,
-	PROTOCOL_FLAG_J1850PWM     = 0x02,
-	PROTOCOL_FLAG_ISO9141      = 0x04,
-	PROTOCOL_FLAG_ISO14230     = 0x08,
-	PROTOCOL_FLAG_CAN          = 0x10,
-	PROTOCOL_FLAG_ISO15765     = 0x20,
-	PROTOCOL_FLAG_SCI_A_ENGINE = 0x40,
-	PROTOCOL_FLAG_SCI_A_TRANS  = 0x80,
-	PROTOCOL_FLAG_SCI_B_ENGINE = 0x100,
-	PROTOCOL_FLAG_SCI_B_TRANS  = 0x200,
-};
-
-
-class J2534Library
-{
-public:
-	std::string path;
-	std::string name;
-	unsigned long protocols;
-	J2534_API_version api;
-
-	J2534Library() { protocols = 0; api = J2534_API_v0404; api = J2534_API_v0404; };
-};
+#include "J2534misc.h"
 
 
 class J2534_API
@@ -125,9 +89,6 @@ private:
 
 	void assignJ2534fcns();
 	static std::vector<J2534Library> searchLibValuesRecursive(HKEY hKey, std::vector<J2534Library> PTlibs);
-#ifdef __J2534_API_DEBUG__
-	static void printLibraryInfo(std::vector<J2534Library> PTlibraries);
-#endif
 
 };
 


### PR DESCRIPTION
No need to hardcode J2534 Linux library anymore.
Building on Windows not tested!

Still C++98 compliant but please keep thinking about switching to C++11, even util functions would benefit from new style already, I would like to upgrade some code accordingly over time. Btw, building Qt 5.7+ itself will depend on a C++11 compiler.

Added minor UI changes in the meantime, not related to J2534.