### PR TITLE
Fix QElapsedTimer error message

### DIFF
--- a/src/SSMP1communication.cpp
+++ b/src/SSMP1communication.cpp
@@ -20,7 +20,7 @@
 #include "SSMP1communication.h"
 
 #include <QTimer>
-
+#include <QElapsedTimer>
 
 SSMP1communication::SSMP1communication(AbstractDiagInterface *diagInterface, SSM1_CUtype_dt cu, unsigned char errRetries) : AbstractSSMcommunication(), SSMP1communication_procedures(diagInterface)
 {

--- a/src/SSMP2communication.cpp
+++ b/src/SSMP2communication.cpp
@@ -21,6 +21,7 @@
 #include "SSMP2communication.h"
 
 #include <QTimer>
+#include <QElapsedTimer>
 
 
 SSMP2communication::SSMP2communication(AbstractDiagInterface *diagInterface, unsigned int cuaddress, unsigned char errRetries) : AbstractSSMcommunication(), SSMP2communication_core(diagInterface)


### PR DESCRIPTION
Added #include <QElapsedTimer> to SSMP1/2 files.

This corrects issue with compiling on Mint 20.x with QT5.

src/SSMP1communication.cpp: In member function ‘virtual void SSMP1communication::run()’:
src/SSMP1communication.cpp:227:2: error: ‘QElapsedTimer’ was not declared in this scope; did you mean ‘QBasicTimer’?
  227 |  QElapsedTimer timer;
      |  ^~~~~~~~~~~~~
      |  QBasicTimer
src/SSMP1communication.cpp:288:3: error: ‘timer’ was not declared in this scope; did you mean ‘time’?
  288 |   timer.start();
      |   ^~~~~
      |   time
src/SSMP1communication.cpp:369:19: error: ‘timer’ was not declared in this scope; did you mean ‘time’?
  369 |     duration_ms = timer.restart();
      |                   ^~~~~
      |                   time
make[1]: *** [Makefile.Release:1661: release/SSMP1communication.o] Error 1