### PR TITLE
Save measurements blocks to csv

### DIFF
--- a/src/CUcontent_MBsSWs.cpp
+++ b/src/CUcontent_MBsSWs.cpp
@@ -363,6 +363,38 @@ bool CUcontent_MBsSWs::startMBSWreading()
 	}
 	else
 		goto err;
+
+	// create csv object and write header
+	csv = new csvfile("test.csv");
+
+	// write header
+	for (size_t i=0; i < _MBSWmetaList.size(); i++)
+	{
+		const MBSWmetadata_dt& metadata = _MBSWmetaList.at(i);
+		
+		std::string title;
+		std::string unit;
+
+		// find title and units
+		if (metadata.blockType == BlockType::MB)
+		{
+			const mb_dt& mb = _supportedMBs.at(metadata.nativeIndex);
+			title = mb.title.toStdString();
+			unit = mb.unit.toStdString();
+		}
+		else if (metadata.blockType == BlockType::SW)
+		{
+			const sw_dt& sw = _supportedSWs.at(metadata.nativeIndex);
+			title = sw.title.toStdString();
+			unit = sw.unit.toStdString();
+		}
+
+		// write to file
+		*csv << title + " (" + unit + ")";
+
+	}
+	*csv << endrow;
+
 	// Reset old data:
 	_lastValues.clear();
 	_minmaxData.clear();
@@ -410,6 +442,8 @@ bool CUcontent_MBsSWs::stopMBSWreading()
 		}
 	}
 	disconnect( _SSMPdev, SIGNAL( newMBSWrawValues(const std::vector<unsigned int>&, int) ), this, SLOT( processMBSWRawValues(const std::vector<unsigned int>&, int) ) );
+	// close csv files (also flushes csv)
+	delete csv;
 	// Set text+icon of start/stop-button:
 	labelStartStopButtonReadyForStart();
 	// Enable delete button if MBs/SWs are selected on the table:
@@ -711,6 +745,13 @@ void CUcontent_MBsSWs::processMBSWRawValues(const std::vector<unsigned int>& raw
 	_valuesTableView->updateMBSWvalues(valueStrList, minValueStrList, maxValueStrList, unitStrList);
 	// Output refresh duration:
 	updateTimeInfo(refreshduration_ms);
+
+	// write to csv
+	for (size_t i=0; i < valueStrList.size(); i++) {
+		std::string value = valueStrList.at(i).toStdString();
+		*csv << value;
+	}
+	*csv << endrow;
 }
 
 

--- a/src/CUcontent_MBsSWs.cpp
+++ b/src/CUcontent_MBsSWs.cpp
@@ -364,8 +364,17 @@ bool CUcontent_MBsSWs::startMBSWreading()
 	else
 		goto err;
 
+	// store start time
+	startTime = std::chrono::high_resolution_clock::now();
+
 	// create csv object and write header
-	csv = new csvfile("test.csv");
+	csv = new csvfile("measurements.csv");
+
+	// global time
+	*csv << "Time";
+
+	// time since measurement
+	*csv << "Delta Time";
 
 	// write header
 	for (size_t i=0; i < _MBSWmetaList.size(); i++)
@@ -747,11 +756,26 @@ void CUcontent_MBsSWs::processMBSWRawValues(const std::vector<unsigned int>& raw
 	updateTimeInfo(refreshduration_ms);
 
 	// write to csv
+	
+	// get timestamp	
+	const auto currTime = std::chrono::high_resolution_clock::now();
+	const std::chrono::duration<double> deltaTime = currTime - startTime;
+
+	// conver to unix epoch time in ms
+	const double unixEpochMs = std::chrono::duration_cast<std::chrono::milliseconds>
+		(currTime.time_since_epoch()).count() / 1000.0;
+	const double deltaEpochMs = std::chrono::duration_cast<std::chrono::milliseconds>
+		(deltaTime).count() / 1000.0;
+
+	// save to csv	
+	*csv << std::fixed << unixEpochMs;
+	*csv << deltaEpochMs;
 	for (size_t i=0; i < valueStrList.size(); i++) {
 		std::string value = valueStrList.at(i).toStdString();
 		*csv << value;
 	}
 	*csv << endrow;
+	csv->flush();
 }
 
 

--- a/src/CUcontent_MBsSWs.h
+++ b/src/CUcontent_MBsSWs.h
@@ -40,6 +40,8 @@
 // To do binary file operations storing the current setup
 #include <fstream>
 
+#include <chrono>
+
 #include "csvfile.h"
 
 class MBSWvalue_dt
@@ -110,6 +112,8 @@ private:
 
 	// pointer to csv file object
 	csvfile *csv = nullptr;
+	// measurement start time (default ot current time)
+	std::chrono::high_resolution_clock::time_point startTime;
 
 	void setupTimeModeUiElements();
 	bool validateMBSWselection(const std::vector<MBSWmetadata_dt>& MBSWmetaList);

--- a/src/CUcontent_MBsSWs.h
+++ b/src/CUcontent_MBsSWs.h
@@ -40,6 +40,8 @@
 // To do binary file operations storing the current setup
 #include <fstream>
 
+#include "csvfile.h"
+
 class MBSWvalue_dt
 {
 public:
@@ -105,6 +107,9 @@ private:
 	std::vector<MinMaxMBSWvalue_dt> _minmaxData;
 	std::vector<unsigned int> _tableRowPosIndexes; /* index of the row at which the MB/SW is displayed in the values-table-widget */
 	bool _MBSWreading;
+
+	// pointer to csv file object
+	csvfile *csv = nullptr;
 
 	void setupTimeModeUiElements();
 	bool validateMBSWselection(const std::vector<MBSWmetadata_dt>& MBSWmetaList);

--- a/src/csvfile.h
+++ b/src/csvfile.h
@@ -1,0 +1,112 @@
+#pragma once
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+class csvfile;
+
+inline static csvfile& endrow(csvfile& file);
+inline static csvfile& flush(csvfile& file);
+
+class csvfile
+{
+    std::ofstream fs_;
+    bool is_first_;
+    const std::string separator_;
+    const std::string escape_seq_;
+    const std::string special_chars_;
+public:
+    csvfile(const std::string filename, const std::string separator = ";")
+        : fs_()
+        , is_first_(true)
+        , separator_(separator)
+        , escape_seq_("\"")
+        , special_chars_("\"")
+    {
+        fs_.exceptions(std::ios::failbit | std::ios::badbit);
+        fs_.open(filename);
+    }
+
+    ~csvfile()
+    {
+        flush();
+        fs_.close();
+    }
+
+    void flush()
+    {
+        fs_.flush();
+    }
+
+    void endrow()
+    {
+        fs_ << std::endl;
+        is_first_ = true;
+    }
+
+    csvfile& operator << ( csvfile& (* val)(csvfile&))
+    {
+        return val(*this);
+    }
+
+    csvfile& operator << (const char * val)
+    {
+        return write(escape(val));
+    }
+
+    csvfile& operator << (const std::string & val)
+    {
+        return write(escape(val));
+    }
+
+    template<typename T>
+    csvfile& operator << (const T& val)
+    {
+        return write(val);
+    }
+
+private:
+    template<typename T>
+    csvfile& write (const T& val)
+    {
+        if (!is_first_)
+        {
+            fs_ << separator_;
+        }
+        else
+        {
+            is_first_ = false;
+        }
+        fs_ << val;
+        return *this;
+    }
+
+    std::string escape(const std::string & val)
+    {
+        std::ostringstream result;
+        result << '"';
+        std::string::size_type to, from = 0u, len = val.length();
+        while (from < len &&
+                std::string::npos != (to = val.find_first_of(special_chars_, from)))
+        {
+            result << val.substr(from, to - from) << escape_seq_ << val[to];
+            from = to + 1;
+        }
+        result << val.substr(from) << '"';
+        return result.str();
+    }
+};
+
+
+inline static csvfile& endrow(csvfile& file)
+{
+    file.endrow();
+    return file;
+}
+
+inline static csvfile& flush(csvfile& file)
+{
+    file.flush();
+    return file;
+}

--- a/src/csvfile.h
+++ b/src/csvfile.h
@@ -1,4 +1,12 @@
-#pragma once
+/**
+ * csvfile.h - Utility for writing CSV files
+ *
+ * Based on this github gist: https://gist.github.com/rudolfovich/f250900f1a833e715260a66c87369d15
+ */
+
+#ifndef CSVFILE_H
+#define CSVFILE_H
+
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -60,6 +68,12 @@ public:
         return write(escape(val));
     }
 
+    csvfile& operator<<(std::ios_base& (*manip)(std::ios_base&))
+    {
+        fs_ << manip;
+        return *this;
+    }
+
     template<typename T>
     csvfile& operator << (const T& val)
     {
@@ -110,3 +124,5 @@ inline static csvfile& flush(csvfile& file)
     file.flush();
     return file;
 }
+
+#endif


### PR DESCRIPTION
Opening this PR as a proof of concept for saving measurement blocks to a csv and looking for feedback from @Comer352L on how you would want it to be implemented to complete the feature.

When you *start* reading measurement blocks it creates/opens a new file ` measurements.csv` overwriting any previous data. Whenever the measurements table is *updated* it writes the unix epoch, time since measurement start, and the measurement blocks to the csv. When measurements *stopped* the file is closed.

Ideally there would a "record" or "start" button with a path input to save the csv as it writes to the directory that `FreeSSM` was started from.

Test on:
- Linux 6.12.16-1-lts
- 2004 Subaru Outback

I attached a csv taken from driving around trying to diag a P0420 code along with excerpt of the first 20 lines.

```
"Time";"Delta Time";"Air/Fuel Sensor #2 Lambda ()";"Air/Fuel Sensor #1 Lambda ()";"Air/Fuel Correction #2 (%)";"Air/Fuel Correction #1 (%)";"Air/Fuel Learning #2 (%)";"Air/Fuel Learning #1 (%)";"Engine Speed (rpm)";"Mass Air Flow (g/s)";"Rear O2 Sensor Voltage (V)";"Front O2 Sensor #2 Voltage (V)";"Front O2 Sensor #1 Voltage (V)"
1743384428.866000;0.184000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"665";"2.42";"0.015";"0.790";"0.790"
1743384429.017000;0.335000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"667";"2.40";"0.015";"0.790";"0.790"
1743384429.191000;0.509000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"670";"2.40";"0.015";"0.790";"0.790"
1743384429.368000;0.686000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"669";"2.44";"0.015";"0.790";"0.790"
1743384429.536000;0.854000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"671";"2.44";"0.015";"0.790";"0.785"
1743384429.701000;1.019000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"663";"2.44";"0.015";"0.790";"0.780"
1743384429.876000;1.194000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"665";"2.44";"0.015";"0.785";"0.780"
1743384430.052000;1.370000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"662";"2.44";"0.015";"0.785";"0.780"
1743384430.218000;1.536000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"667";"2.40";"0.015";"0.785";"0.780"
1743384430.385000;1.703000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"669";"2.44";"0.015";"0.785";"0.785"
1743384430.560000;1.878000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"665";"2.44";"0.015";"0.785";"0.785"
1743384430.728000;2.046000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"660";"2.44";"0.015";"0.790";"0.790"
1743384430.903000;2.220000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"667";"2.47";"0.015";"0.790";"0.790"
1743384431.072000;2.390000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"661";"2.44";"0.015";"0.795";"0.785"
1743384431.238000;2.556000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"663";"2.42";"0.015";"0.800";"0.765"
1743384431.403000;2.721000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"659";"2.44";"0.015";"0.800";"0.730"
1743384431.573000;2.891000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"658";"2.45";"0.015";"0.800";"0.680"
1743384431.742000;3.060000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"665";"2.44";"0.015";"0.805";"0.630"
1743384431.906000;3.224000;"1.00";"1.00";"0.0";"0.8";"-1.6";"-7.0";"668";"2.42";"0.015";"0.805";"0.615"
```

[running.csv](https://github.com/user-attachments/files/19538112/running.csv)

Resolves #18 and #78 